### PR TITLE
PR - remove class properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,20 @@ console.log(instance instanceof Dog)
 // expected output - true
 ```
 
+
+
+
+
+
+
 ### Behavioral
 Well known behavioral patterns
 
 #### Bridge
-A take on the well known bridge pattern. Allows for any two methods of class instances to be joined, resulting in a return of an executable function.
+A take on the well known bridge pattern. Allows for any two methods of class instances to be joined, resulting in a return of an executable function. The `bridge` function takes scope to be applied to a function and then returns a `to` function to join another scope and a function. The `to` function when called then returns an `execute` function that accepts the same argument parameters as the initial function passed to `bridge`. It then calls the first joined function and using its return value as arguments to the second joined function, calls the second, returning its return value.
 
 ```javascript
-import { Bridge } from 'js-software-design-patterns';
+import { bridge } from 'js-software-design-patterns';
 
 class Remote {
     changeChannelTo = (channel) => {
@@ -133,12 +139,10 @@ class TV {
 
 const remote = new Remote();
 const tv = new TV();
-const bridge = new Bridge();
 
-const channelChanger = bridge.join(remote.changeChannelTo, tv.changeChannelTo);
-
-
-channelChanger(20);
+const to = bridge(remote, remote.changeChannelTo);
+const execute = to(tv, tv.changeChannelTo);
+execute(20);
 // expected output -
 //      Remote changing channel to 20.
 //      TV set to channel 20.

--- a/src/__tests__/patterns/behavioral/bridge.test.js
+++ b/src/__tests__/patterns/behavioral/bridge.test.js
@@ -1,4 +1,4 @@
-import Bridge from '../../../patterns/behavioral/bridge';
+import bridge from '../../../patterns/behavioral/bridge';
 
 class TV {
 	constructor(name) {
@@ -15,7 +15,6 @@ class Remote {
 	}
 
 	channelUp() {
-		console.warn(this);
 		this.channel++;
 		return this.channel;
 	}
@@ -32,40 +31,28 @@ class Remote {
 }
 
 describe('Bridge tests', () => {
-	let bridge;
 	let remote;
 	let tv;
 
 	beforeEach(() => {
-		bridge = new Bridge();
 		remote = new Remote();
 		tv = new TV('Bedroom TV');
 	});
 
-	it('should construct with empty mappings', () => {
-		// uses a weak map, so checking to make sure that is the case
-		expect(bridge.functionMappings instanceof WeakMap).toBe(true);
-	});
-
-	it('should bridge 2 class instances functions', () => {
-		bridge.join(remote.channelUp, tv.setChannel);
-		expect(bridge.functionMappings.get(remote.channelUp)).toBe(tv.setChannel);
-	});
-
 	it('should return a function to execute', () => {
-		const callable = bridge.join(remote.channelUp, tv.setChannel);
+		const callable = bridge(remote, remote.channelUp)(tv, tv.setChannel);
 		expect(typeof callable).toEqual('function');
 	});
 
 	it('should bridge function calls, returning correct value', () => {
-		const channelUp = bridge.join(remote.channelUp, tv.setChannel);
-		const channelDown = bridge.join(remote.channelDown, tv.setChannel);
+		const channelUp = bridge(remote, remote.channelUp)(tv, tv.setChannel);
+		const channelDown = bridge(remote, remote.channelDown)(tv, tv.setChannel);
 		expect(channelUp()).toBe('Bedroom TV had its channel changed to 1');
 		expect(channelDown()).toBe('Bedroom TV had its channel changed to 0');
 	});
 
 	it('should accept arguments with return callable function', () => {
-		const changeTo = bridge.join(remote.jumpToChannel, tv.setChannel);
+		const changeTo = bridge(remote, remote.jumpToChannel)(tv, tv.setChannel);
 		expect(changeTo(20)).toBe('Bedroom TV had its channel changed to 20');
 	});
 });

--- a/src/__tests__/patterns/behavioral/bridge.test.js
+++ b/src/__tests__/patterns/behavioral/bridge.test.js
@@ -4,25 +4,31 @@ class TV {
 	constructor(name) {
 		this.name = name;
 	}
-	setChannel = channel => `${this.name} had its channel changed to ${channel}`;
+	setChannel(channel) {
+		return `${this.name} had its channel changed to ${channel}`;
+	}
 }
 
 class Remote {
-	channel = 0;
-	channelUp = () => {
+	constructor() {
+		this.channel = 0;
+	}
+
+	channelUp() {
+		console.warn(this);
 		this.channel++;
 		return this.channel;
-	};
+	}
 
-	channelDown = () => {
+	channelDown() {
 		this.channel--;
 		return this.channel;
-	};
+	}
 
-	jumpToChannel = channel => {
+	jumpToChannel(channel) {
 		this.channel = channel;
 		return this.channel;
-	};
+	}
 }
 
 describe('Bridge tests', () => {

--- a/src/__tests__/patterns/behavioral/chain-of-responsibilty.test.js
+++ b/src/__tests__/patterns/behavioral/chain-of-responsibilty.test.js
@@ -7,7 +7,7 @@ class TestChainItem extends ChainOfResponsibility {
 	}
 
 	executeOn(number = 0) {
-		this.number + number;
+		return this.number + number;
 	}
 }
 

--- a/src/__tests__/patterns/behavioral/chain-of-responsibilty.test.js
+++ b/src/__tests__/patterns/behavioral/chain-of-responsibilty.test.js
@@ -6,7 +6,9 @@ class TestChainItem extends ChainOfResponsibility {
 		this.number = number;
 	}
 
-	executeOn = (number = 0) => this.number + number;
+	executeOn(number = 0) {
+		this.number + number;
+	}
 }
 
 describe('Chain of responsibility tests', () => {

--- a/src/patterns/behavioral/bridge.js
+++ b/src/patterns/behavioral/bridge.js
@@ -1,16 +1,20 @@
 class Bridge {
-	functionMappings = new WeakMap();
+	functionMappings = new Map();
 
 	join = (keyFunc, nextFunc) => {
-		this.functionMappings.set(keyFunc, nextFunc);
-		return this._apply(keyFunc);
+		this.functionMappings.set(keyFunc.name, nextFunc);
+		const me = this;
+		return (...args) => {
+			const value = keyFunc(args);
+			return me.functionMappings.get(keyFunc.name)(value);
+		};
 	};
 
 	_apply = keyFunc => {
 		const me = this;
-		return function() {
-			const value = keyFunc(...arguments);
-			return me.functionMappings.get(keyFunc)(value);
+		return (...args) => {
+			const value = keyFunc(args);
+			return me.functionMappings.get(keyFunc.name)(value);
 		};
 	};
 }

--- a/src/patterns/behavioral/bridge.js
+++ b/src/patterns/behavioral/bridge.js
@@ -1,22 +1,3 @@
-class Bridge {
-	functionMappings = new Map();
+const bridge = (keyScope, keyFunc) => (toScope, toFunc) => (...args) => toFunc.apply(toScope, [keyFunc.apply(keyScope, args)]);
 
-	join = (keyFunc, nextFunc) => {
-		this.functionMappings.set(keyFunc.name, nextFunc);
-		const me = this;
-		return (...args) => {
-			const value = keyFunc(args);
-			return me.functionMappings.get(keyFunc.name)(value);
-		};
-	};
-
-	_apply = keyFunc => {
-		const me = this;
-		return (...args) => {
-			const value = keyFunc(args);
-			return me.functionMappings.get(keyFunc.name)(value);
-		};
-	};
-}
-
-export default Bridge;
+export default bridge;

--- a/src/patterns/behavioral/chain-of-responsibility.js
+++ b/src/patterns/behavioral/chain-of-responsibility.js
@@ -7,13 +7,13 @@ class ChainOfResponsibility {
 		this.next = next;
 	}
 
-	executeOn = () => {};
+	executeOn() {}
 
-	execute = previousValues => {
+	execute(previousValues) {
 		const val = this.executeOn(previousValues);
 		if (!this.next) return val;
 		return this.next.execute(val);
-	};
+	}
 }
 
 export default ChainOfResponsibility;

--- a/src/patterns/behavioral/index.js
+++ b/src/patterns/behavioral/index.js
@@ -1,10 +1,10 @@
-import Bridge from './bridge';
+import bridge from './bridge';
 import ChainOfResponsibility from './chain-of-responsibility';
 import Commander from './command';
 import PubSub from './pubsub';
 
 module.exports = {
-	Bridge,
+	bridge,
 	ChainOfResponsibility,
 	Commander,
 	PubSub,


### PR DESCRIPTION
It turns out writing tests with the proposed class properties is a _bad idea_. This PR has the initial removal of them and intentionally breaks the tests. 

Work needs to be done to repair those patterns