### PR TITLE
commander now takes an optionally supplied scope

### DIFF
--- a/src/__tests__/patterns/behavioral/command.test.js
+++ b/src/__tests__/patterns/behavioral/command.test.js
@@ -47,4 +47,29 @@ describe('Commander tests', () => {
 		expect(nowRun).toHaveBeenCalledTimes(1);
 		expect(run).toHaveBeenCalledTimes(1);
 	});
+
+	it('should have the scope of the passed', () => {
+		class Test {
+			getScope() {
+				this.scope = this;
+			}
+		}
+		const t = new Test();
+		commander.register('scopeTest', t.getScope, t);
+		commander.execute('scopeTest');
+		expect(t.scope).toBe(t);
+	});
+
+	it('should have the scope of the commander if no scope is passed', () => {
+		const c = new Commander();
+		class Test {
+			getScope() {
+				this.scope = 'commander';
+			}
+		}
+		const t = new Test();
+		c.register('scopeTest', t.getScope);
+		c.execute('scopeTest');
+		expect(c.scope).toEqual('commander');
+	});
 });

--- a/src/patterns/behavioral/command.js
+++ b/src/patterns/behavioral/command.js
@@ -1,15 +1,19 @@
 class Commander {
 	commands = new Map();
-
-	register = (command, executeFunc) => {
-		if (!this.commands.has(command)) this.commands.set(command, new Set());
+	scopes = new WeakMap();
+	register = (command, executeFunc, scope) => {
+		if (!this.commands.has(command)) {
+			this.commands.set(command, new Set());
+		}
 		this.commands.get(command).add(executeFunc);
+		const appliedScope = scope || this;
+		this.scopes.set(executeFunc, appliedScope);
 	};
 
 	execute = (command, ...args) => {
 		if (!this.commands.has(command)) throw new Error(`The command '${command}' you are trying to execute doesnt exist`);
 		const funcs = this.commands.get(command);
-		funcs.forEach(func => func.apply(this, args));
+		funcs.forEach(func => func.apply(this.scopes.get(func), args));
 	};
 }
 


### PR DESCRIPTION
commander now takes an optional third argument on register (`scope`);

example: 
```javascript

// applies the scope of this current object 
commander.register('example', this.onExample, this);

// applies the scope of the commander 
commander.register('example', Dog.bark);

```

closes #22 